### PR TITLE
Fixed typewriteComplete never called issue

### DIFF
--- a/src/typewrite.js
+++ b/src/typewrite.js
@@ -109,8 +109,8 @@
             var chars = blankstr.split('');
             chars.forEach(function(char, index){
                 $(settings.el).delay(settings.speed).queue(function (next){
-                    index++;
-                    var newTo = action.to - index;
+                    var newIndex = index + 1;
+                    var newTo = action.to - newIndex;
                     $(settings.el).html($(settings.el).html().replace(/<br.*?>/g, ' \n '));
                     var currentString = $(settings.el).text();
                     var firstPart = currentString.slice(0, newTo);

--- a/src/typewrite.js
+++ b/src/typewrite.js
@@ -81,6 +81,7 @@
             // changes the typing speed
             if(Object.keys(element)[0] === 'speed'){
                 settings.speed = 1000 / element.speed;
+	        settings.queue = settings.queue - 1;
             }
 
             // removes characters


### PR DESCRIPTION
When chars.length is 1, the `index++` will make `index === chars.length - 1` be always false -

So the queue will never be cleared, typewriteComplete won't be called for sure.

Probably related to #7 